### PR TITLE
Fix overflow for groups exceeding tray width

### DIFF
--- a/index.html
+++ b/index.html
@@ -867,6 +867,15 @@
           offset += widthUsed;
         });
 
+        // If combined width exceeds tray width, scale positions to fit
+        const totalWidthUsed = offset;
+        if (totalWidthUsed > trayW + 1e-6) {
+          const fitScale = trayW / totalWidthUsed;
+          placedAll.forEach(p => { p.x *= fitScale; });
+          barrierLines = barrierLines.map(x => x * fitScale);
+          offset = trayW;
+        }
+
         // 7) Determine if ALL cables are Control/Signal
         const allCS = cables.every(c => c.cableType === "Control" || c.cableType === "Signal");
 


### PR DESCRIPTION
## Summary
- scale group placements if total width exceeds tray

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686be6a501f88324803bfcb14afda827