### PR TITLE
Add multiconductor cable option

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,6 +237,7 @@
           <th>Cable Configuration</th>
           <th>OD (in)</th>
           <th>Weight (lbs/ft)</th>
+          <th>Multiconductor Cable</th>
           <th>Cable Group</th>
           <th>Duplicate</th>
           <th>Remove</th>
@@ -393,7 +394,14 @@
         tdWt.appendChild(inpWt);
         tr.appendChild(tdWt);
 
-        // (6) Cable Group cell
+        // (6) Multiconductor checkbox
+        const tdMulti = document.createElement("td");
+        const inpMulti = document.createElement("input");
+        inpMulti.type = "checkbox";
+        tdMulti.appendChild(inpMulti);
+        tr.appendChild(tdMulti);
+
+        // (7) Cable Group cell
         const tdGrp = document.createElement("td");
         const inpGrp = document.createElement("input");
         inpGrp.type = "number";
@@ -404,7 +412,7 @@
         tdGrp.appendChild(inpGrp);
         tr.appendChild(tdGrp);
 
-        // (7) Duplicate button cell
+        // (8) Duplicate button cell
         const tdDup = document.createElement("td");
         const btnDup = document.createElement("button");
         btnDup.type = "button";
@@ -419,9 +427,11 @@
           cfgClone.dispatchEvent(new Event("input"));
           const odClone = clone.children[3].querySelector("input");
           const wtClone = clone.children[4].querySelector("input");
-          const grpClone = clone.children[5].querySelector("input");
+          const multiClone = clone.children[5].querySelector("input");
+          const grpClone = clone.children[6].querySelector("input");
           odClone.value = inpOD.value;
           wtClone.value = inpWt.value;
+          multiClone.checked = inpMulti.checked;
           grpClone.value = inpGrp.value;
           odClone.readOnly = inpOD.readOnly;
           wtClone.readOnly = inpWt.readOnly;
@@ -430,7 +440,7 @@
         tdDup.appendChild(btnDup);
         tr.appendChild(tdDup);
 
-        // (7) Remove button cell
+        // (9) Remove button cell
         const tdRm = document.createElement("td");
         const btnRm = document.createElement("button");
         btnRm.type = "button";
@@ -784,7 +794,8 @@
           const configVal  = row.children[2].querySelector("input").value.trim();
           const odVal      = parseFloat(row.children[3].querySelector("input").value);
           const wtVal      = parseFloat(row.children[4].querySelector("input").value);
-          const groupVal   = parseInt(row.children[5].querySelector("input").value) || 1;
+          const multiVal   = row.children[5].querySelector("input").checked;
+          const groupVal   = parseInt(row.children[6].querySelector("input").value) || 1;
 
           if (!tagVal) {
             alert("ERROR: Every cable row requires a Tag.");
@@ -809,6 +820,7 @@
             config: configVal,
             OD: odVal,
             weight: wtVal,
+            multi: multiVal,
             group: groupVal
           });
         }
@@ -1350,15 +1362,16 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
           return;
         }
         // Build 2D array: header + each row’s [Tag, Cable Type, Cable Configuration, OD, Weight, Group]
-        const data = [["Tag", "Cable Type", "Cable Configuration", "OD", "Weight", "Group"]];
+        const data = [["Tag", "Cable Type", "Cable Configuration", "OD", "Weight", "Multiconductor Cable", "Group"]];
         rows.forEach(row => {
           const tag       = row.children[0].querySelector("input").value.trim();
           const cableType = row.children[1].querySelector("select").value;
           const config    = row.children[2].querySelector("input").value.trim();
           const od        = row.children[3].querySelector("input").value.trim();
           const weight    = row.children[4].querySelector("input").value.trim();
-          const group     = row.children[5].querySelector("input").value.trim();
-          data.push([tag, cableType, config, od, weight, group]);
+          const multi     = row.children[5].querySelector("input").checked ? "TRUE" : "FALSE";
+          const group     = row.children[6].querySelector("input").value.trim();
+          data.push([tag, cableType, config, od, weight, multi, group]);
         });
         const wb = XLSX.utils.book_new();
         const ws = XLSX.utils.aoa_to_sheet(data);
@@ -1385,10 +1398,10 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
             alert("Excel sheet is empty.");
             return;
           }
-          // Expect columns: Tag, Cable Type, Cable Configuration, OD, Weight, Group
+          // Expect columns: Tag, Cable Type, Cable Configuration, OD, Weight, Multiconductor Cable, Group
           cableTbody.innerHTML = "";
           jsonArr.forEach((obj, idx) => {
-            const { Tag, "Cable Type": CableType, "Cable Configuration": Config, OD, Weight, Group } = obj;
+            const { Tag, "Cable Type": CableType, "Cable Configuration": Config, OD, Weight, "Multiconductor Cable": Multi, Group } = obj;
             if (
               typeof Tag === "undefined" ||
               typeof CableType === "undefined" ||
@@ -1411,13 +1424,15 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
             // If not matched a default, fill custom OD/Weight
             const odInput = newRow.children[3].querySelector("input");
             const wtInput = newRow.children[4].querySelector("input");
-            const grpInput = newRow.children[5].querySelector("input");
+            const multiInput = newRow.children[5].querySelector("input");
+            const grpInput = newRow.children[6].querySelector("input");
             if (cableOptions.findIndex(o => o.label === Config) < 0) {
               odInput.value = parseFloat(OD).toFixed(2);
               wtInput.value = parseFloat(Weight).toFixed(2);
               odInput.readOnly = false;
               wtInput.readOnly = false;
             }
+            multiInput.checked = String(Multi).toLowerCase() === "true";
             grpInput.value = Group || 1;
             cableTbody.appendChild(newRow);
           });
@@ -1432,7 +1447,7 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
         alert(
           "Import Instructions:\n" +
           "1. Click 'Export Excel' to download a template.\n" +
-          "2. Fill in Tag, Cable Type, Cable Configuration, OD, Weight, and Group.\n" +
+          "2. Fill in Tag, Cable Type, Cable Configuration, OD, Weight, Multiconductor Cable, and Group.\n" +
           "3. Save the file then choose it with 'Import Excel'."
         );
       });
@@ -1442,7 +1457,7 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
         alert(
           "Import Instructions:\n" +
           "1. Click 'Export Excel' to download a template.\n" +
-          "2. Fill in Tag, Cable Type, Cable Configuration, OD, Weight, and Group.\n" +
+          "2. Fill in Tag, Cable Type, Cable Configuration, OD, Weight, Multiconductor Cable, and Group.\n" +
           "3. Save the file then choose it with 'Import Excel'."
         );
       });
@@ -1452,7 +1467,7 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
         alert(
           "Import Instructions:\n" +
           "1. Click 'Export Excel' to download a template.\n" +
-          "2. Fill in Tag, Cable Type, Cable Configuration, OD, Weight, and Group.\n" +
+          "2. Fill in Tag, Cable Type, Cable Configuration, OD, Weight, Multiconductor Cable, and Group.\n" +
           "3. Save the file then choose it with 'Import Excel'."
         );
       });
@@ -1463,7 +1478,7 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
           "Import Instructions:\n" +
           "1. Click 'Export Excel' to download a template.\n" +
 
-          "2. Fill in Tag, Cable Type, Cable Configuration, OD, Weight, and Group.\n" +
+          "2. Fill in Tag, Cable Type, Cable Configuration, OD, Weight, Multiconductor Cable, and Group.\n" +
 
           "3. Save the file then choose it with 'Import Excel'."
         );
@@ -1509,7 +1524,8 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
           const configVal  = row.children[2].querySelector("input").value.trim();
           const odVal      = parseFloat(row.children[3].querySelector("input").value);
           const wtVal      = parseFloat(row.children[4].querySelector("input").value);
-          const groupVal   = parseInt(row.children[5].querySelector("input").value) || 1;
+          const multiVal   = row.children[5].querySelector("input").checked;
+          const groupVal   = parseInt(row.children[6].querySelector("input").value) || 1;
           if (!tagVal || !cableType || !configVal || isNaN(odVal) || isNaN(wtVal)) {
             alert("All rows must have Tag, Cable Type, Configuration, OD, and Weight before saving.");
             return;
@@ -1520,6 +1536,7 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
             config: configVal,
             OD: odVal,
             weight: wtVal,
+            multi: multiVal,
             group: groupVal
           });
         }
@@ -1563,13 +1580,15 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
           cfgInput.dispatchEvent(new Event("input"));
           const odInput = newRow.children[3].querySelector("input");
           const wtInput = newRow.children[4].querySelector("input");
-          const grpInput = newRow.children[5].querySelector("input");
+          const multiInput = newRow.children[5].querySelector("input");
+          const grpInput = newRow.children[6].querySelector("input");
           if (cableOptions.findIndex(o => o.label === cable.config) < 0) {
             odInput.value = cable.OD.toFixed(2);
             wtInput.value = cable.weight.toFixed(2);
             odInput.readOnly = false;
             wtInput.readOnly = false;
           }
+          multiInput.checked = !!cable.multi;
           grpInput.value = cable.group || 1;
           cableTbody.appendChild(newRow);
         });


### PR DESCRIPTION
## Summary
- extend cable table with `Multiconductor Cable` checkbox
- persist multi-conductor flag across duplicate, import/export, profiles and drawing logic
- update import/export help text

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686bf4122bcc8324be544103c7e2f61d