### PR TITLE
Update cable group help text

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,7 +266,7 @@
           <th>Operating Voltage (V) <button class="helpBtn" data-help="Actual working voltage on the cable.">?</button></th>
           <th>OD (in) <button class="helpBtn" data-help="Outer diameter of the cable in inches.">?</button></th>
           <th>Weight (lbs/ft) <button class="helpBtn" data-help="Cable weight per foot.">?</button></th>
-          <th>Cable Group <button class="helpBtn" data-help="Numeric group for organizing cables.">?</button></th>
+          <th>Cable Group <button class="helpBtn" data-help="Numeric group for organizing cables. If Stackable and Non-Stackable Cables are placed in the same group than a divider will automatically be added.">?</button></th>
           <th>Duplicate</th>
           <th>Remove</th>
         </tr>


### PR DESCRIPTION
## Summary
- expand the help popup for the Cable Group column to clarify automatic dividers when mixing stackable and non-stackable cables

## Testing
- `grep -n "Stackable" -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_686d216c619083248d67e3ba05408411