### PR TITLE
Add Circuit Group column

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,6 +267,7 @@
           <th>OD (in) <button class="helpBtn" data-help="Outer diameter of the cable in inches.">?</button></th>
           <th>Weight (lbs/ft) <button class="helpBtn" data-help="Cable weight per foot.">?</button></th>
           <th>Cable Zone <button class="helpBtn" data-help="Numeric zone for organizing cables. If Stackable and Non-Stackable Cables are placed in the same zone then a divider will automatically be added.">?</button></th>
+          <th>Circuit Group <button class="helpBtn" data-help="Numeric group for bundling single conductor cables in groups of 3 or 4 conductors.">?</button></th>
           <th>Duplicate</th>
           <th>Remove</th>
         </tr>
@@ -460,7 +461,19 @@
         inpZone.value = "1";
         tdZone.appendChild(inpZone);
         tr.appendChild(tdZone);
-        // (10) Duplicate button cell
+
+        // (10) Circuit Group cell
+        const tdGroup = document.createElement("td");
+        const inpGroup = document.createElement("input");
+        inpGroup.type = "number";
+        inpGroup.step = "1";
+        inpGroup.min = "1";
+        inpGroup.style.width = "50px";
+        inpGroup.value = "1";
+        tdGroup.appendChild(inpGroup);
+        tr.appendChild(tdGroup);
+
+        // (11) Duplicate button cell
         const tdDup = document.createElement("td");
         const btnDup = document.createElement("button");
         btnDup.type = "button";
@@ -478,12 +491,14 @@
           const voltClone   = clone.children[5].querySelector("input");
           const odClone     = clone.children[6].querySelector("input");
           const wtClone     = clone.children[7].querySelector("input");
-          const zoneClone    = clone.children[8].querySelector("input");
+          const zoneClone   = clone.children[8].querySelector("input");
+          const groupClone  = clone.children[9].querySelector("input");
           ratingClone.value = inpRating.value;
           voltClone.value   = inpVolt.value;
           odClone.value     = inpOD.value;
           wtClone.value     = inpWt.value;
-          zoneClone.value    = inpZone.value;
+          zoneClone.value   = inpZone.value;
+          groupClone.value  = inpGroup.value;
           odClone.readOnly = inpOD.readOnly;
           wtClone.readOnly = inpWt.readOnly;
           cableTbody.insertBefore(clone, tr.nextSibling);
@@ -491,7 +506,7 @@
         tdDup.appendChild(btnDup);
         tr.appendChild(tdDup);
 
-        // (11) Remove button cell
+        // (12) Remove button cell
         const tdRm = document.createElement("td");
         const btnRm = document.createElement("button");
         btnRm.type = "button";
@@ -876,7 +891,8 @@
           const voltVal     = parseFloat(row.children[5].querySelector("input").value);
           const odVal       = parseFloat(row.children[6].querySelector("input").value);
           const wtVal       = parseFloat(row.children[7].querySelector("input").value);
-          const zoneVal    = parseInt(row.children[8].querySelector("input").value) || 1;
+          const zoneVal     = parseInt(row.children[8].querySelector("input").value) || 1;
+          const groupVal    = parseInt(row.children[9].querySelector("input").value) || 1;
           const multiVal   = countVal > 1;
 
           if (!tagVal) {
@@ -906,7 +922,8 @@
             OD: odVal,
             weight: wtVal,
             multi: multiVal,
-            zone: zoneVal
+            zone: zoneVal,
+            circuitGroup: groupVal
           });
         }
         if (cables.length === 0) {
@@ -1505,7 +1522,8 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
           "Operating Voltage (V)",
           "OD",
           "Weight",
-          "Zone"
+          "Zone",
+          "Circuit Group"
         ]];
         rows.forEach(row => {
           const tag       = row.children[0].querySelector("input").value.trim();
@@ -1516,8 +1534,9 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
           const voltage   = row.children[5].querySelector("input").value.trim();
           const od        = row.children[6].querySelector("input").value.trim();
           const weight    = row.children[7].querySelector("input").value.trim();
-          const zone     = row.children[8].querySelector("input").value.trim();
-          data.push([tag, cableType, count, size, rating, voltage, od, weight, zone]);
+          const zone      = row.children[8].querySelector("input").value.trim();
+          const group     = row.children[9].querySelector("input").value.trim();
+          data.push([tag, cableType, count, size, rating, voltage, od, weight, zone, group]);
         });
         const wb = XLSX.utils.book_new();
         const ws = XLSX.utils.aoa_to_sheet(data);
@@ -1544,7 +1563,7 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
             alert("Excel sheet is empty.");
             return;
           }
-          // Expect columns: Tag, Cable Type, Conductors, Conductor Size, Cable Rating (V), Operating Voltage (V), OD, Weight, Zone
+          // Expect columns: Tag, Cable Type, Conductors, Conductor Size, Cable Rating (V), Operating Voltage (V), OD, Weight, Zone, Circuit Group
           cableTbody.innerHTML = "";
           jsonArr.forEach((obj, idx) => {
             const {
@@ -1556,7 +1575,8 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
               "Operating Voltage (V)": Voltage,
               OD,
               Weight,
-              Zone
+              Zone,
+              "Circuit Group": CircuitGroup
             } = obj;
             if (
               typeof Tag === "undefined" ||
@@ -1587,6 +1607,7 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
             const odInput = newRow.children[6].querySelector("input");
             const wtInput = newRow.children[7].querySelector("input");
             const zoneInput = newRow.children[8].querySelector("input");
+            const groupInput = newRow.children[9].querySelector("input");
             if (cableOptions.findIndex(o => o.conductors === parseInt(Conductors) && o.size === Size) < 0) {
               odInput.value = parseFloat(OD).toFixed(2);
               wtInput.value = parseFloat(Weight).toFixed(2);
@@ -1594,6 +1615,7 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
               wtInput.readOnly = false;
             }
             zoneInput.value = Zone || 1;
+            groupInput.value = obj["Circuit Group"] || 1;
             cableTbody.appendChild(newRow);
           });
           alert("Excel imported. Correct any unrecognized conductor details if needed.");
@@ -1607,7 +1629,7 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
         alert(
           "Import Instructions:\n" +
           "1. Click 'Export Excel' to download a template.\n" +
-          "2. Fill in Tag, Cable Type, Conductors, Conductor Size, Cable Rating (V), Operating Voltage (V), OD, Weight, and Zone.\n" +
+            "2. Fill in Tag, Cable Type, Conductors, Conductor Size, Cable Rating (V), Operating Voltage (V), OD, Weight, Zone, and Circuit Group.\n" +
           "3. Save the file then choose it with 'Import Excel'."
         );
       });
@@ -1656,7 +1678,8 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
           const voltVal    = parseFloat(row.children[5].querySelector("input").value);
           const odVal      = parseFloat(row.children[6].querySelector("input").value);
           const wtVal      = parseFloat(row.children[7].querySelector("input").value);
-          const zoneVal   = parseInt(row.children[8].querySelector("input").value) || 1;
+          const zoneVal    = parseInt(row.children[8].querySelector("input").value) || 1;
+          const groupVal   = parseInt(row.children[9].querySelector("input").value) || 1;
           const multiVal  = countVal > 1;
           if (!tagVal || !cableType || !countVal || !sizeVal || isNaN(odVal) || isNaN(wtVal)) {
             alert("All rows must have Tag, Cable Type, conductor count/size, OD, and Weight before saving.");
@@ -1672,7 +1695,8 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
             OD: odVal,
             weight: wtVal,
             multi: multiVal,
-            zone: zoneVal
+            zone: zoneVal,
+            circuitGroup: groupVal
           });
         }
         try {
@@ -1718,6 +1742,7 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
           const odInput = newRow.children[6].querySelector("input");
           const wtInput = newRow.children[7].querySelector("input");
           const zoneInput = newRow.children[8].querySelector("input");
+          const groupInput = newRow.children[9].querySelector("input");
           if (cableOptions.findIndex(o => o.conductors === cable.count && o.size === cable.size) < 0) {
             odInput.value = cable.OD.toFixed(2);
             wtInput.value = cable.weight.toFixed(2);
@@ -1725,6 +1750,7 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
             wtInput.readOnly = false;
           }
           zoneInput.value = cable.zone || 1;
+          groupInput.value = cable.circuitGroup || 1;
           cableTbody.appendChild(newRow);
         });
         alert(`Profile "${profileName}" loaded.`);


### PR DESCRIPTION
## Summary
- add `Circuit Group` column to cable entry table
- duplicate rows and profile management store the new circuit group value
- update Excel import/export logic and instructions for new column
- show help text explaining circuit grouping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d29118f54832488b3e3551ad53bf0