### PR TITLE
Add sub-zone fill calculations

### DIFF
--- a/index.html
+++ b/index.html
@@ -1074,9 +1074,21 @@
             const widthLimit = info.width * scale;
             const result = placeZone(info.cables, widthLimit, spacingEnabled);
             const widthUsed = result.widthUsed;
-            const areaAll = sumAreas(info.orig);
-            const fillP = widthUsed > 0 ? Math.min(100, (areaAll / (widthUsed * trayD)) * 100) : 0;
-            html += `<p><strong>Zone ${info.zid} Fill %:</strong> ${fillP.toFixed(0)} %</p>`;
+            const { large: origLarge, small: origSmall } = splitLargeSmall(info.orig);
+            if (result.largeCount > 0 && result.smallCount > 0) {
+              const areaLarge = sumAreas(origLarge);
+              const areaSmall = sumAreas(origSmall);
+              const widthLarge = result.barrierX;
+              const widthSmall = widthUsed - result.barrierX;
+              const fillLarge = widthLarge > 0 ? Math.min(100, (areaLarge / (widthLarge * trayD)) * 100) : 0;
+              const fillSmall = widthSmall > 0 ? Math.min(100, (areaSmall / (widthSmall * trayD)) * 100) : 0;
+              html += `<p><strong>Zone ${info.zid}.1 Fill %:</strong> ${fillLarge.toFixed(0)} %</p>`;
+              html += `<p><strong>Zone ${info.zid}.2 Fill %:</strong> ${fillSmall.toFixed(0)} %</p>`;
+            } else {
+              const areaAll = sumAreas(info.orig);
+              const fillP = widthUsed > 0 ? Math.min(100, (areaAll / (widthUsed * trayD)) * 100) : 0;
+              html += `<p><strong>Zone ${info.zid} Fill %:</strong> ${fillP.toFixed(0)} %</p>`;
+            }
             if (off > 0) lines.push(off);
             if (result.largeCount > 0 && result.smallCount > 0) lines.push(off + result.barrierX);
             result.placed.forEach(p => { p.x += off; placed.push(p); });


### PR DESCRIPTION
## Summary
- show separate fill percentages for non-stackable and stackable cables in the same zone

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d3c9d0f58832498a042dcd48767a6