### PR TITLE
Fix zone labeling when zones contain mixed cables

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,7 +357,7 @@
       let lastTrayD   = 0;     // in inches
       let lastType    = "";    // “ladder” or “solid”
       let lastScale   = 20;    // px/in for small view
-      let lastZones   = [];    // array of zone ids in order
+      let lastZones   = [];    // array of zone labels in order
 
       // Reference to <tbody> in the cable table
       const cableTbody = document.querySelector("#cableTable tbody");
@@ -1032,6 +1032,7 @@
         let offset = 0;
         let zoneHTML = "";
         let voltageWarning = "";
+        let zoneNames = [];
 
         // First pass: determine natural width of each zone
         const zoneInfo = [];
@@ -1070,6 +1071,7 @@
           let off = 0;
           let html = "";
           const lines = [];
+          const names = [];
           const placed = [];
           zoneInfo.forEach(info => {
             const widthLimit = info.width * scale;
@@ -1091,11 +1093,17 @@
               html += `<p><strong>Zone ${info.zid} Fill %:</strong> ${fillP.toFixed(0)} %</p>`;
             }
             if (off > 0) lines.push(off);
-            if (result.largeCount > 0 && result.smallCount > 0) lines.push(off + result.barrierX);
+            if (result.largeCount > 0 && result.smallCount > 0) {
+              lines.push(off + result.barrierX);
+              names.push(`${info.zid}.1`);
+              names.push(`${info.zid}.2`);
+            } else {
+              names.push(`${info.zid}`);
+            }
             result.placed.forEach(p => { p.x += off; placed.push(p); });
             off += widthUsed;
           });
-          return { placed, lines, width: off, html };
+          return { placed, lines, names, width: off, html };
         }
 
         // Try packing with iterative scaling until width fits within the tray
@@ -1107,6 +1115,7 @@
 
         placedAll    = layout.placed;
         barrierLines = layout.lines;
+        zoneNames    = layout.names;
         offset       = layout.width;
         zoneHTML    = layout.html;
 
@@ -1193,7 +1202,7 @@
         lastTrayD    = trayD;
         lastType     = trayType;
         lastScale    = 20;  // px/in for small view
-        lastZones    = zoneIds.slice();
+        lastZones    = zoneNames.slice();
 
         // 14) Detect overflow horizontally/vertically
         let overflowHoriz = false;
@@ -1257,12 +1266,12 @@
           const xe = zoneBounds[i+1] * scale;
           const mid = (xs + xe) / 2;
           const wText = (zoneBounds[i+1] - zoneBounds[i]).toFixed(1) + '"';
-          const zoneText = `Zone ${zoneIds[i]}`;
+          const zoneLabel = zoneNames[i] ? `Zone ${zoneNames[i]}` : 'Zone Unknown';
           svg += `
             <line x1="${xs.toFixed(2)}" y1="${dimLineY}" x2="${xe.toFixed(2)}" y2="${dimLineY}" stroke="#000" stroke-width="1" />
             <line x1="${xs.toFixed(2)}" y1="${dimLineY-4}" x2="${xs.toFixed(2)}" y2="${dimLineY+4}" stroke="#000" stroke-width="1" />
             <line x1="${xe.toFixed(2)}" y1="${dimLineY-4}" x2="${xe.toFixed(2)}" y2="${dimLineY+4}" stroke="#000" stroke-width="1" />
-            <text x="${mid.toFixed(2)}" y="${dimLineY-6}" font-size="10px" text-anchor="middle" font-family="Arial, sans-serif">${zoneText}</text>
+            <text x="${mid.toFixed(2)}" y="${dimLineY-6}" font-size="10px" text-anchor="middle" font-family="Arial, sans-serif">${zoneLabel}</text>
             <text x="${mid.toFixed(2)}" y="${dimLineY+10}" font-size="10px" text-anchor="middle" font-family="Arial, sans-serif">${wText}</text>
           `;
         }
@@ -1448,12 +1457,12 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
           const xe = bigZone[i+1] * bigScale;
           const mid = (xs + xe) / 2;
           const wText = (bigZone[i+1] - bigZone[i]).toFixed(1) + '"';
-          const zoneText = `Zone ${lastZones[i]}`;
+          const zoneLabel = lastZones[i] ? `Zone ${lastZones[i]}` : 'Zone Unknown';
           svg += `
             <line x1="${xs.toFixed(2)}" y1="${dimLineY}" x2="${xe.toFixed(2)}" y2="${dimLineY}" stroke="#000" stroke-width="2" />
             <line x1="${xs.toFixed(2)}" y1="${dimLineY-8}" x2="${xs.toFixed(2)}" y2="${dimLineY+8}" stroke="#000" stroke-width="2" />
             <line x1="${xe.toFixed(2)}" y1="${dimLineY-8}" x2="${xe.toFixed(2)}" y2="${dimLineY+8}" stroke="#000" stroke-width="2" />
-            <text x="${mid.toFixed(2)}" y="${dimLineY-12}" font-size="18px" text-anchor="middle" font-family="Arial, sans-serif">${zoneText}</text>
+            <text x="${mid.toFixed(2)}" y="${dimLineY-12}" font-size="18px" text-anchor="middle" font-family="Arial, sans-serif">${zoneLabel}</text>
             <text x="${mid.toFixed(2)}" y="${dimLineY+16}" font-size="18px" text-anchor="middle" font-family="Arial, sans-serif">${wText}</text>
           `;
         }


### PR DESCRIPTION
## Summary
- track zone segment names during layout
- use these names in small and expanded SVG views to label zone dimensions
- store zone labels for expanded view

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686d42a2449c83248be447e42bcba7f8