### PR TITLE
Add global help overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,10 +198,60 @@
       display: block;
       margin-top: 48px;  /* room for buttons */
     }
+
+    /* GLOBAL HELP STYLES */
+    #globalHelpBtn {
+      position: fixed;
+      top: 8px;
+      right: 8px;
+      background: #3498db;
+      color: white;
+      border: none;
+      border-radius: 4px;
+      padding: 6px 12px;
+      font-size: 0.9rem;
+      cursor: pointer;
+      z-index: 1100;
+    }
+    #helpOverlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0,0,0,0.5);
+      display: none;
+      justify-content: center;
+      align-items: center;
+      z-index: 1200;
+    }
+    #helpPopup {
+      position: relative;
+      background: white;
+      padding: 12px;
+      border-radius: 8px;
+      max-width: 90%;
+      max-height: 90%;
+      overflow: auto;
+      box-shadow: 0 0 10px rgba(0,0,0,0.5);
+    }
+    #helpClose {
+      position: absolute;
+      top: 8px;
+      right: 8px;
+      background: #e74c3c;
+      color: white;
+      border: none;
+      font-size: 1rem;
+      padding: 4px 8px;
+      cursor: pointer;
+      border-radius: 4px;
+    }
   </style>
 </head>
 <body>
   <h1>Cable Tray Packing</h1>
+  <button id="globalHelpBtn" type="button">Help</button>
 
   <!-- TRAY PARAMETERS -->
   <fieldset>
@@ -314,6 +364,34 @@
       <button id="copyBtn" type="button">Copy SVG</button>
       <!-- Expanded SVG will be injected here -->
       <div id="expandedSVG"></div>
+    </div>
+  </div>
+
+  <!-- HELP OVERLAY -->
+  <div id="helpOverlay">
+    <div id="helpPopup">
+      <button id="helpClose" type="button">Close</button>
+      <div id="helpContent">
+        <h2>Help Documentation</h2>
+        <p>This page calculates cable tray fill and displays a tray diagram.</p>
+        <h3>Tray Parameters</h3>
+        <p>Specify the tray width, load depth, tray type and an optional name.</p>
+        <h3>Profile Management</h3>
+        <p>Save or load groups of cables as profiles stored in your browser.</p>
+        <h3>Entering Cables</h3>
+        <p>Use <em>Add Cable</em> to create rows. Each column's <strong>?</strong> button explains the field.</p>
+        <h3>Controls</h3>
+        <ul>
+          <li><strong>Add one-diameter spacing</strong> adds separation for non-stackable cables.</li>
+          <li><strong>Draw Tray</strong> generates a small tray diagram.</li>
+          <li><strong>Expand Image</strong> opens a larger graphic with copy and print options.</li>
+          <li><strong>Import/Export Excel</strong> transfers the cable list to and from Excel.</li>
+          <li><strong>Import Help</strong> shows tips for formatting Excel files.</li>
+        </ul>
+        <h3>Results</h3>
+        <p>After drawing, tray size recommendations and fill details appear along with the graphic.</p>
+        <p>Use the blue help buttons throughout the page for quick explanations of specific fields.</p>
+      </div>
     </div>
   </div>
 
@@ -1971,6 +2049,14 @@ Wt: ${m.weight.toFixed(2)} lbs/ft
 
       // Initialize profile dropdown
       refreshProfileList();
+
+      // Global help overlay
+      document.getElementById("globalHelpBtn").addEventListener("click", () => {
+        document.getElementById("helpOverlay").style.display = "flex";
+      });
+      document.getElementById("helpClose").addEventListener("click", () => {
+        document.getElementById("helpOverlay").style.display = "none";
+      });
 
       // Attach help popups for table headers
       document.querySelectorAll('.helpBtn').forEach(btn => {


### PR DESCRIPTION
## Summary
- add `Help` button in the top-right corner
- provide new overlay with documentation for using the page
- wire up JavaScript to open and close the help overlay

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d452bca5c83248f6806e3ed0a0948