### PR TITLE
Fix zone label overlap in expanded tray view

### DIFF
--- a/index.html
+++ b/index.html
@@ -1483,7 +1483,7 @@ Wt: ${p.weight.toFixed(2)} lbs/ft
         const bigScale = 160;  // 160 px/in for high resolution
         const trayW = lastTrayW, trayD = lastTrayD;
         const trayName = document.getElementById("trayName").value.trim();
-        const nameRowPx    = 30;   // give more room for big text
+        const nameRowPx    = 40;   // give more room for big text and spacing
         const dimRowPx     = 36;   // more room for dimension text
         const trayRowPx    = trayD * bigScale;
         const totalSvgH    = nameRowPx + dimRowPx + trayRowPx;


### PR DESCRIPTION
## Summary
- increase spacing above zone labels in expanded SVG

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686d50dd05088324ac71773861634478